### PR TITLE
SIOS-1112: Update build scripts to be iOS 7.1 compliant

### DIFF
--- a/Scripts/generate-coverage-report.sh
+++ b/Scripts/generate-coverage-report.sh
@@ -6,20 +6,29 @@ if [ "$RUN_CLI" = "" ]; then
   exit 0
 fi
 
-INFO_DIR="${PROJECT_DIR}/build/test-coverage/"
-OUTPUT_DIR="${PROJECT_DIR}/build/test-coverage/${PRODUCT_NAME}"
-LCOV_PATH=${SRCROOT}/Scripts/lcov-1.10/bin
-LCOV=${LCOV_PATH}/lcov
+export INFO_DIR="${PROJECT_DIR}/build/test-coverage/"
+export OUTPUT_DIR="${PROJECT_DIR}/build/test-coverage/${PRODUCT_NAME}"
+export LCOV_PATH=${SRCROOT}/Scripts/lcov-1.10/bin
+export LCOV=${LCOV_PATH}/lcov
+echo $INFO_DIR
+echo $OUTPUT_DIR
+echo $LCOV_PATH
+echo $LCOV
 
 mkdir -p "$OUTPUT_DIR"
 mkdir -p "$INFO_DIR"
 
-TITLE="${PROJECT_NAME} - ${PRODUCT_NAME}"
-SOCIALIZE_LIB_DIR="Socialize.build"
-INFO_TMP_FILE="${INFO_DIR}/${PRODUCT_NAME}-Coverage_tmp.info"
-INFO_FILE="${INFO_DIR}/${PRODUCT_NAME}-Coverage.info"
+export TITLE="${PROJECT_NAME} - ${PRODUCT_NAME}"
+export SOCIALIZE_LIB_DIR="Socialize.build"
+export INFO_TMP_FILE="${INFO_DIR}/${PRODUCT_NAME}-Coverage_tmp.info"
+export INFO_FILE="${INFO_DIR}/${PRODUCT_NAME}-Coverage.info"
+export INPUT_DIR="$CONFIGURATION_TEMP_DIR/$SOCIALIZE_LIB_DIR/Objects-normal/i386/"
 
-"${LCOV}" --test-name "${TITLE}" --output-file "$INFO_TMP_FILE" --capture --directory "$CONFIGURATION_TEMP_DIR/$SOCIALIZE_LIB_DIR/Objects-normal/i386/"
+echo $TITLE
+echo $INPUT_DIR
+echo "${LCOV} --test-name ${TITLE} --output-file $INFO_TMP_FILE --capture --directory $INPUT_DIR"
+
+"${LCOV}" --test-name "${TITLE}" --output-file "$INFO_TMP_FILE" --capture --directory "$INPUT_DIR"
 "${LCOV}" --extract "${INFO_TMP_FILE}" "*/Socialize*/*" --output-file "${INFO_FILE}"
 
 "${LCOV_PATH}/genhtml" --title "${TITLE}"  --output-directory "$OUTPUT_DIR" "$INFO_FILE" --legend

--- a/Scripts/lcov-1.10/bin/geninfo
+++ b/Scripts/lcov-1.10/bin/geninfo
@@ -1858,35 +1858,40 @@ sub read_gcov_file($)
 # GCOV version. Version numbers can be compared using standard integer
 # operations.
 #
-
+# MODIFIED per http://stackoverflow.com/questions/22343725/xcode-5-1-unit-test-coverage-analysis-fails-on-files-using-blocks
+#
 sub get_gcov_version()
 {
-	local *HANDLE;
-	my $version_string;
-	my $result;
+    local *HANDLE;
+    my $version_string;
+    my $result;
 
-	open(GCOV_PIPE, "-|", "$gcov_tool -v")
-		or die("ERROR: cannot retrieve gcov version!\n");
-	$version_string = <GCOV_PIPE>;
-	close(GCOV_PIPE);
+    open(GCOV_PIPE, "-|", "$gcov_tool --version")
+        or die("ERROR: cannot retrieve gcov version!\n");
+    $version_string = <GCOV_PIPE>;
+    close(GCOV_PIPE);
 
-	$result = 0;
-	if ($version_string =~ /(\d+)\.(\d+)(\.(\d+))?/)
-	{
-		if (defined($4))
-		{
-			info("Found gcov version: $1.$2.$4\n");
-			$result = $1 << 16 | $2 << 8 | $4;
-		}
-		else
-		{
-			info("Found gcov version: $1.$2\n");
-			$result = $1 << 16 | $2 << 8;
-		}
-	}
-	return ($result, $version_string);
+    $result = 0;
+    if ($version_string =~ m/LLVM/)
+    {
+        info("Found llvm-cov\n");
+        $result = 0x40201;
+    }
+    elsif ($version_string =~ /(\d+)\.(\d+)(\.(\d+))?/)
+    {
+        if (defined($4))
+        {
+            info("Found gcov version: $1.$2.$4\n");
+            $result = $1 << 16 | $2 << 8 | $4;
+        }
+        else
+        {
+            info("Found gcov version: $1.$2\n");
+            $result = $1 << 16 | $2 << 8;
+        }
+    }
+    return ($result, $version_string);
 }
-
 
 #
 # info(printf_parameter)

--- a/Scripts/run-headless-simulator.sh
+++ b/Scripts/run-headless-simulator.sh
@@ -11,9 +11,13 @@ if [ -z "$RUN_CLI" ]; then
   exit 0
 fi
 
-if [ -n "$SIMVER_OVERRIDE" ]; then
-    export SDKROOT="$DEVELOPER_DIR/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator${SIMVER_OVERRIDE}.sdk/"
-fi
+# if [ -n "$SIMVER_OVERRIDE" ]; then
+# DOES NOT WORK with 7.1 simulator; force version to 7.0
+    export SDKROOT="$DEVELOPER_DIR/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator7.0.sdk/"
+    # export SDKROOT="$DEVELOPER_DIR/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator${SIMVER_OVERRIDE}.sdk/"
+# fi
+
+echo "SDKROOT =" $SDKROOT
 
 echo DYLD_ROOT_PATH = "$SDKROOT"
 export DYLD_ROOT_PATH="$SDKROOT"
@@ -50,14 +54,9 @@ fi
 mkdir "$CFFIXED_USER_HOME"
 mkdir "$CFFIXED_USER_HOME/Documents"
 mkdir -p "$CFFIXED_USER_HOME/Library/Caches"
-
-# securityd for keychain / auth
-#LAUNCHNAME="RunIPhoneLaunchDaemons"
-#launchctl submit -l $LAUNCHNAME -- "${THISDIR}/RunIPhoneLaunchDaemons.sh" $IPHONE_SIMULATOR_ROOT $CFFIXED_USER_HOME
-#trap "launchctl remove $LAUNCHNAME" INT TERM EXIT
+echo "CFFIXED_USER_HOME =" $CFFIXED_USER_HOME
 
 killall "iPhone Simulator" >/dev/null 2>&1
-#RUN_CMD="gdb --args \"$TEST_TARGET_EXECUTABLE_PATH\" -RegisterForSystemEvents"
 RUN_CMD="\"$TEST_TARGET_EXECUTABLE_PATH\" -RegisterForSystemEvents"
 
 echo "Running: $RUN_CMD"


### PR DESCRIPTION
Updated build scripts, including fix for lcov (code coverage scripts) and set version explicitly to iOS 7.0 in build command; at some point we'll have to get build command working for iOS 7.1+, but no need to do so just yet...
